### PR TITLE
Make examples executable with rosrun

### DIFF
--- a/examples/txrospy_client.py
+++ b/examples/txrospy_client.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from twisted.internet import defer, reactor
 
 from txrospy import protocol

--- a/examples/txrospy_client_thrift.py
+++ b/examples/txrospy_client_thrift.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from twisted.internet import defer, reactor
 
 from txrospy import protocol_thrift

--- a/examples/txrospy_listener.py
+++ b/examples/txrospy_listener.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 import time
 

--- a/examples/txrospy_server.py
+++ b/examples/txrospy_server.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from twisted.application import service, internet
 from twisted.internet import defer, reactor
 

--- a/examples/txrospy_server_thrift.py
+++ b/examples/txrospy_server_thrift.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from twisted.application import service, internet
 from twisted.internet import defer, reactor
 

--- a/examples/txrospy_talker.py
+++ b/examples/txrospy_talker.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import time
 
 from twisted.internet import defer, reactor


### PR DESCRIPTION
Without the sha-bang, rosrun doesn't interpret the files as python scripts.
